### PR TITLE
Feature User Impersonation

### DIFF
--- a/app/Http/Controllers/Admin/DashboardController.php
+++ b/app/Http/Controllers/Admin/DashboardController.php
@@ -40,7 +40,7 @@ class DashboardController extends Controller
 
     public function indexUsers(FilterUser $request)
     {
-        $users = User::where('name', 'like', $request->input('query') . '%')->filter($request->validated());
+        $users = User::where('name', 'like', $request->input('query') . '%')->filter($request->validated())->latest();
 
         return $request->export === 'xlsx'
             ? Excel::download(new UsersExport($users->get()), 'users.xlsx')
@@ -49,7 +49,7 @@ class DashboardController extends Controller
 
     public function indexEntities(FilterEntity $request)
     {
-        $entities = Entity::where('name', 'like', $request->input('query') . '%')->filter($request->validated());
+        $entities = Entity::where('name', 'like', $request->input('query') . '%')->filter($request->validated())->latest();
 
         return $request->export === 'xlsx'
             ? Excel::download(new EntitiesExport($entities->get()), 'entities.xlsx')

--- a/app/Http/Controllers/Admin/ImpersonateController.php
+++ b/app/Http/Controllers/Admin/ImpersonateController.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace App\Http\Controllers\Admin;
+
+use App\Http\Controllers\Controller;
+use Illuminate\Http\Request;
+use Illuminate\Support\Arr;
+
+class ImpersonateController extends Controller
+{
+    public function index()
+    {
+        auth()->guard('web')->logout();
+
+        return redirect(route('admin.users'));
+    }
+
+    public function store(Request $request)
+    {
+        auth()->guard('web')->loginUsingId(Arr::get($request->validate(['user_id' => 'required|exists:users,id']), 'user_id'));
+
+        return redirect(route('home'));
+    }
+}

--- a/database/factories/MessageFactory.php
+++ b/database/factories/MessageFactory.php
@@ -13,7 +13,7 @@ class MessageFactory extends Factory
     public function definition(): array
     {
         return [
-            'id'         => $this->faker->randomDigit + time(),
+            'id'         => $this->faker->unique()->randomDigit,
             'type'       => 'user',
             'from_id'    => User::factory(),
             'to_id'      => User::factory(),

--- a/resources/views/admin/users.blade.php
+++ b/resources/views/admin/users.blade.php
@@ -77,6 +77,8 @@
                     </td>
                     <td class="center aligned">
                         <a href="#" onclick="handleViewUser(event, {{$user->id}});"><i class="eye blue icon"></i></a>
+                        <a href="#" onclick="handleImpersonateUser(event, {{$user->id}});"><i
+                                class="secret user blue icon"></i></a>
                         <a href="#" onclick="handleDeleteUser(event, {{$user->id}});"><i class="trash red icon"></i></a>
                     </td>
                     <td>
@@ -164,6 +166,10 @@
     <form id="user_verify_form" action="" method="POST">
         @csrf
     </form>
+    <form action="{{route('admin.impersonate.store')}}" id="user_impersonate_form" method="post">
+        @csrf
+        <input type="hidden" name="user_id" id="impersonation_id" value="">
+    </form>
 @endsection
 
 @section('scripts')
@@ -210,6 +216,12 @@
             e.preventDefault();
             var url = '/admin/api/profile/' + id;
             $('#user_delete_form').attr('action', url).submit();
+        }
+
+        function handleImpersonateUser(e, id) {
+            e.preventDefault();
+            $('#impersonation_id').val(id);
+            $('#user_impersonate_form').submit();
         }
 
         $('.verify.user.checkbox').change(function () {

--- a/resources/views/partials/navigation.blade.php
+++ b/resources/views/partials/navigation.blade.php
@@ -72,7 +72,8 @@
                                     <i class="university blue icon"></i> My Business
                                 </a>
                                 <div class="ui blue inverted item" style="background: none !important;">
-                                    <form method="post" action="{{route('logout')}}">
+                                    <form method="get"
+                                          action="@auth('admin'){{route('admin.impersonate.index')}}@else{{route('logout')}}@endauth">
                                         @csrf
                                         <button type="submit" class="ui teal fluid button">Logout</button>
                                     </form>
@@ -103,7 +104,7 @@
                 <div class="right aligned seven wide column">
                     <button onclick="$('#mobileMenu').toggle('fade');" class="ui grey button"
                             style="margin-top: 20px;margin-right: -30px;padding: 10px 5px 10px 15px;"><i
-                                class="bars black icon"></i></button>
+                            class="bars black icon"></i></button>
                 </div>
             @endauth
             @guest
@@ -169,7 +170,8 @@
                         <div class="item"><a href="{{route('profile.entities')}}">MY ORGANIZATIONS</a></div>
                         <br>
                         <div class="ui blue inverted " style="background: none !important;">
-                            <form method="post" action="{{route('logout')}}">
+                            <form method="get"
+                                  action="@auth('admin'){{route('admin.impersonate.index')}}@else{{route('logout')}}@endauth">
                                 @csrf
                                 <button type="submit" class="ui teal fluid button">Logout</button>
                             </form>

--- a/routes/admin.php
+++ b/routes/admin.php
@@ -16,10 +16,12 @@ Route::namespace('Admin')->group(function () {
     Route::get('/users', 'DashboardController@indexUsers')->name('users');
     Route::get('/entities', 'DashboardController@indexEntities')->name('entities');
     Route::resource('admins', 'AdminController')->only(['index', 'edit', 'update']);
+    Route::resource('impersonate', 'ImpersonateController')->only(['store', 'index']);
 });
 
 Route::resource('entityType', 'EntityTypeController')->except(['index', 'create', 'show', 'edit']);
 Route::resource('sector', 'SectorController')->except(['index', 'create', 'show', 'edit']);
+
 Route::prefix('/api')->group(function () {
     $profileRoute = 'profile/{profile}';
     $entityRoute = 'entity/{entity}';

--- a/tests/Feature/ExampleTest.php
+++ b/tests/Feature/ExampleTest.php
@@ -8,15 +8,10 @@ use Tests\TestCase;
 class ExampleTest extends TestCase
 {
     use RefreshDatabase;
-    /**
-     * A basic test example.
-     *
-     * @return void
-     */
+
     public function testBasicTest()
     {
-        $response = $this->get('/messenger');
-
-        $response->assertRedirect('login');
+        $this->get('/messenger')
+            ->assertRedirect('login');
     }
 }

--- a/tests/Feature/ImpersonationTest.php
+++ b/tests/Feature/ImpersonationTest.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Admin;
+use App\Models\User;
+use Illuminate\Foundation\Testing\DatabaseTransactions;
+use Tests\TestCase;
+
+class ImpersonationTest extends TestCase
+{
+    use DatabaseTransactions;
+
+    protected $user, $admin;
+
+    public function testAdminCanImpersonateAUser(): void
+    {
+        $this->actingAs($this->admin, 'admin')
+            ->get(route('admin.users'))
+            ->assertSee('secret user blue icon');
+
+        $this->actingAs($this->admin, 'admin')
+            ->post(route('admin.impersonate.store'), ['user_id' => $this->user->id])
+            ->assertRedirect(route('home'));
+
+        $this->assertAuthenticatedAs($this->user, 'web');
+    }
+
+    public function testUserCanNotAccessImpersonationRoutes(): void
+    {
+        $this->actingAs($this->user)->get(route('admin.users'))->assertRedirect(route('admin.login'));
+        $this->actingAs($this->user)->post(route('admin.impersonate.store'), ['user_id' => $this->user->id])->assertRedirect(route('admin.login'));
+    }
+
+    public function testAdminCanQuitImpersonation(): void
+    {
+        $this->actingAs($this->admin, 'admin')
+            ->post(route('admin.impersonate.store'), ['user_id' => $this->user->id]);
+        $this->assertNotNull(auth()->guard('web')->user());
+        $this->assertAuthenticatedAs($this->user, 'web');
+        $this->actingAs($this->admin, 'admin')->get(route('admin.impersonate.index'))
+            ->assertRedirect(route('admin.users'));
+        $this->assertNull(auth()->guard('web')->user());
+    }
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->admin = Admin::factory()->create();
+        $this->user = User::factory()->create();
+    }
+}

--- a/tests/Feature/ImpersonationTest.php
+++ b/tests/Feature/ImpersonationTest.php
@@ -11,16 +11,18 @@ class ImpersonationTest extends TestCase
 {
     use DatabaseTransactions;
 
+    protected const IMPERSONATION_ROUTE = 'admin.impersonate.store';
+    protected const USERS_ROUTE = 'admin.users';
     protected $user, $admin;
 
     public function testAdminCanImpersonateAUser(): void
     {
         $this->actingAs($this->admin, 'admin')
-            ->get(route('admin.users'))
+            ->get(route(self::USERS_ROUTE))
             ->assertSee('secret user blue icon');
 
         $this->actingAs($this->admin, 'admin')
-            ->post(route('admin.impersonate.store'), ['user_id' => $this->user->id])
+            ->post(route(self::IMPERSONATION_ROUTE), ['user_id' => $this->user->id])
             ->assertRedirect(route('home'));
 
         $this->assertAuthenticatedAs($this->user, 'web');
@@ -28,18 +30,18 @@ class ImpersonationTest extends TestCase
 
     public function testUserCanNotAccessImpersonationRoutes(): void
     {
-        $this->actingAs($this->user)->get(route('admin.users'))->assertRedirect(route('admin.login'));
-        $this->actingAs($this->user)->post(route('admin.impersonate.store'), ['user_id' => $this->user->id])->assertRedirect(route('admin.login'));
+        $this->actingAs($this->user)->get(route(self::USERS_ROUTE))->assertRedirect(route('admin.login'));
+        $this->actingAs($this->user)->post(route(self::IMPERSONATION_ROUTE), ['user_id' => $this->user->id])->assertRedirect(route('admin.login'));
     }
 
     public function testAdminCanQuitImpersonation(): void
     {
         $this->actingAs($this->admin, 'admin')
-            ->post(route('admin.impersonate.store'), ['user_id' => $this->user->id]);
+            ->post(route(self::IMPERSONATION_ROUTE), ['user_id' => $this->user->id]);
         $this->assertNotNull(auth()->guard('web')->user());
         $this->assertAuthenticatedAs($this->user, 'web');
         $this->actingAs($this->admin, 'admin')->get(route('admin.impersonate.index'))
-            ->assertRedirect(route('admin.users'));
+            ->assertRedirect(route(self::USERS_ROUTE));
         $this->assertNull(auth()->guard('web')->user());
     }
 


### PR DESCRIPTION
Added user impersonation to the portal:
 - An admin can impersonate a user by clicking on the impersonation icon next to their name in users list
 - An admin can restore access to their backend by clicking on logout in users' account